### PR TITLE
add IFR_setup_BTH.cmd to enable verbose Bluetooth driver tracing

### DIFF
--- a/bluetooth/tracing/IFR_setup_BTH.cmd
+++ b/bluetooth/tracing/IFR_setup_BTH.cmd
@@ -1,58 +1,42 @@
 rem Setting up IFR on bthport and bthusb
 @REG ADD "HKLM\System\CurrentControlSet\Services\BTHUSB\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
-@REG ADD "HKLM\System\CurrentControlSet\Services\BTHUSB\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
-
 @REG ADD "HKLM\System\CurrentControlSet\Services\BTHPORT\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
-@REG ADD "HKLM\System\CurrentControlSet\Services\BTHPORT\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
 
 rem Setting up IFR on bthmini
 @REG ADD "HKLM\System\CurrentControlSet\Services\BTHMini\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
-@REG ADD "HKLM\System\CurrentControlSet\Services\BTHMini\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
 
 rem Setting up IFR on bthuart
 @REG ADD "HKLM\System\CurrentControlSet\Services\BTHuart\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
-@REG ADD "HKLM\System\CurrentControlSet\Services\BTHuart\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
 
 rem Setting up IFR on hidclass and hidbth
 @REG ADD "HKLM\System\CurrentControlSet\Services\HIDBTH\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
-@REG ADD "HKLM\System\CurrentControlSet\Services\HIDBTH\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
 
 rem Setting up IFR on bthenum
 @REG ADD "HKLM\System\CurrentControlSet\Services\BTHENUM\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
-@REG ADD "HKLM\System\CurrentControlSet\Services\BTHENUM\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
 
 rem Setting up IFR on bthprint
 @REG ADD "HKLM\System\CurrentControlSet\Services\BTHPRINT\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
-@REG ADD "HKLM\System\CurrentControlSet\Services\BTHPRINT\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
 
 rem Setting up IFR on bthmodem
 @REG ADD "HKLM\System\CurrentControlSet\Services\BTHMODEM\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
-@REG ADD "HKLM\System\CurrentControlSet\Services\BTHMODEM\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
 
 rem Setting up IFR on rfcomm
 @REG ADD "HKLM\System\CurrentControlSet\Services\RFCOMM\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
-@REG ADD "HKLM\System\CurrentControlSet\Services\RFCOMM\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
 
 rem Setting up IFR on bthserv
 @REG ADD "HKLM\System\CurrentControlSet\Services\bthserv\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
-@REG ADD "HKLM\System\CurrentControlSet\Services\bthserv\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
 
 rem Setting up IFR on bthleenum
 @REG ADD "HKLM\System\CurrentControlSet\Services\bthleenum\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
-@REG ADD "HKLM\System\CurrentControlSet\Services\bthleenum\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
 
 rem Setting up IFR on btha2dp
 @REG ADD "HKLM\System\CurrentControlSet\Services\btha2dp\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
-@REG ADD "HKLM\System\CurrentControlSet\Services\btha2dp\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
 
 rem Setting up IFR on bthhfenum
 @REG ADD "HKLM\System\CurrentControlSet\Services\bthhfenum\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
-@REG ADD "HKLM\System\CurrentControlSet\Services\bthhfenum\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
 
 rem Setting up IFR on bthhfaud
 @REG ADD "HKLM\System\CurrentControlSet\Services\bthhfaud\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
-@REG ADD "HKLM\System\CurrentControlSet\Services\bthhfaud\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
 
 rem Setting up IFR on bthhfhid
 @REG ADD "HKLM\System\CurrentControlSet\Services\bthhfhid\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
-@REG ADD "HKLM\System\CurrentControlSet\Services\bthhfhid\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f

--- a/bluetooth/tracing/IFR_setup_BTH.cmd
+++ b/bluetooth/tracing/IFR_setup_BTH.cmd
@@ -1,0 +1,58 @@
+rem Setting up IFR on bthport and bthusb
+@REG ADD "HKLM\System\CurrentControlSet\Services\BTHUSB\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
+@REG ADD "HKLM\System\CurrentControlSet\Services\BTHUSB\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
+
+@REG ADD "HKLM\System\CurrentControlSet\Services\BTHPORT\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
+@REG ADD "HKLM\System\CurrentControlSet\Services\BTHPORT\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
+
+rem Setting up IFR on bthmini
+@REG ADD "HKLM\System\CurrentControlSet\Services\BTHMini\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
+@REG ADD "HKLM\System\CurrentControlSet\Services\BTHMini\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
+
+rem Setting up IFR on bthuart
+@REG ADD "HKLM\System\CurrentControlSet\Services\BTHuart\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
+@REG ADD "HKLM\System\CurrentControlSet\Services\BTHuart\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
+
+rem Setting up IFR on hidclass and hidbth
+@REG ADD "HKLM\System\CurrentControlSet\Services\HIDBTH\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
+@REG ADD "HKLM\System\CurrentControlSet\Services\HIDBTH\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
+
+rem Setting up IFR on bthenum
+@REG ADD "HKLM\System\CurrentControlSet\Services\BTHENUM\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
+@REG ADD "HKLM\System\CurrentControlSet\Services\BTHENUM\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
+
+rem Setting up IFR on bthprint
+@REG ADD "HKLM\System\CurrentControlSet\Services\BTHPRINT\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
+@REG ADD "HKLM\System\CurrentControlSet\Services\BTHPRINT\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
+
+rem Setting up IFR on bthmodem
+@REG ADD "HKLM\System\CurrentControlSet\Services\BTHMODEM\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
+@REG ADD "HKLM\System\CurrentControlSet\Services\BTHMODEM\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
+
+rem Setting up IFR on rfcomm
+@REG ADD "HKLM\System\CurrentControlSet\Services\RFCOMM\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
+@REG ADD "HKLM\System\CurrentControlSet\Services\RFCOMM\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
+
+rem Setting up IFR on bthserv
+@REG ADD "HKLM\System\CurrentControlSet\Services\bthserv\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
+@REG ADD "HKLM\System\CurrentControlSet\Services\bthserv\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
+
+rem Setting up IFR on bthleenum
+@REG ADD "HKLM\System\CurrentControlSet\Services\bthleenum\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
+@REG ADD "HKLM\System\CurrentControlSet\Services\bthleenum\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
+
+rem Setting up IFR on btha2dp
+@REG ADD "HKLM\System\CurrentControlSet\Services\btha2dp\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
+@REG ADD "HKLM\System\CurrentControlSet\Services\btha2dp\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
+
+rem Setting up IFR on bthhfenum
+@REG ADD "HKLM\System\CurrentControlSet\Services\bthhfenum\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
+@REG ADD "HKLM\System\CurrentControlSet\Services\bthhfenum\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
+
+rem Setting up IFR on bthhfaud
+@REG ADD "HKLM\System\CurrentControlSet\Services\bthhfaud\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
+@REG ADD "HKLM\System\CurrentControlSet\Services\bthhfaud\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f
+
+rem Setting up IFR on bthhfhid
+@REG ADD "HKLM\System\CurrentControlSet\Services\bthhfhid\Parameters" /v "VerboseOn" /t  REG_DWORD /d 0x1 /f
+@REG ADD "HKLM\System\CurrentControlSet\Services\bthhfhid\Parameters" /v "LogPages" /t  REG_DWORD /d 0xFF /f


### PR DESCRIPTION
Adds a batch script to enable verbose tracing in Windows Bluetooth drivers.