### PR TITLE
stop override when changing pages

### DIFF
--- a/sensors/Tools/SensorExplorer/code/SensorExplorer/Scenario3_DEO.xaml.cs
+++ b/sensors/Tools/SensorExplorer/code/SensorExplorer/Scenario3_DEO.xaml.cs
@@ -41,6 +41,15 @@ namespace SensorExplorer
             PeriodicTimer.CreateScenario3();
         }
 
+        protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
+        {
+            deo.StopOverride();
+
+            deo.IsOverrideActiveChanged -= Deo_IsOverrideActiveChanged;
+            deo.CanOverrideChanged -= Deo_CanOverrideChanged;
+            deo.DisplayEnhancementOverrideCapabilitiesChanged -= Deo_DisplayEnhancementOverrideCapabilitiesChanged;
+        }
+
         private void OnSelectionChangedPercentage(object sender, SelectionChangedEventArgs e)
         {
             if (comboBoxPercentage.SelectedItem != null)

--- a/sensors/Tools/SensorExplorer/code/SensorExplorer/Scenario3_DEO.xaml.cs
+++ b/sensors/Tools/SensorExplorer/code/SensorExplorer/Scenario3_DEO.xaml.cs
@@ -8,6 +8,7 @@ using Windows.Graphics.Display;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Navigation;
 
 namespace SensorExplorer
 {


### PR DESCRIPTION
When the page goes from the DEO page to another one of the pages (Tests, View, MALT), the current DEO override is not correctly stopped. We would need to close sensorexplorer to completely stop the DEO request.

With this change, changing from the DEO page to any of the other modes correctly stops DEO

Verified via:
put sensorexplorer on laptop and verify that display enhancement override is not stopped when we change the mode
put new sensorexplorer private on laptop and verify that display enhancement override is correctly stopped when we change the mode