### PR TITLE
Add PercentageOfTotalMemory and MaximumBufferSpace tags

### DIFF
--- a/bluetooth/tracing/BluetoothStack.wprp
+++ b/bluetooth/tracing/BluetoothStack.wprp
@@ -20,17 +20,17 @@
 
     <EventCollector Id="Traces_paged_verbose" Name="Event Collector Paged (Verbose)">
       <BufferSize Value="1024"/>
-	    <Buffers Value="8" PercentageOfTotalMemory="true" MaximumBufferSpace="64" />
+      <Buffers Value="8" PercentageOfTotalMemory="true" MaximumBufferSpace="64" />
     </EventCollector>
 
     <EventCollector Id="Traces_nonpaged_verbose" Name="Event Collector NonPaged (Verbose)">
       <BufferSize Value="1024"/>
-	    <Buffers Value="8" PercentageOfTotalMemory="true" MaximumBufferSpace="64" />
+      <Buffers Value="8" PercentageOfTotalMemory="true" MaximumBufferSpace="64" />
     </EventCollector>
 
     <EventCollector Id="Bthport_ETW" Name="Event Collector Bthport ETW">
       <BufferSize Value="1024"/>
-	    <Buffers Value="8" PercentageOfTotalMemory="true" MaximumBufferSpace="64" />
+      <Buffers Value="8" PercentageOfTotalMemory="true" MaximumBufferSpace="64" />
     </EventCollector>
 
     <!-- Paged providers. They are kept separate for readability -->

--- a/bluetooth/tracing/BluetoothStack.wprp
+++ b/bluetooth/tracing/BluetoothStack.wprp
@@ -20,17 +20,17 @@
 
     <EventCollector Id="Traces_paged_verbose" Name="Event Collector Paged (Verbose)">
       <BufferSize Value="1024"/>
-      <Buffers Value="16"/>
+	    <Buffers Value="8" PercentageOfTotalMemory="true" MaximumBufferSpace="64" />
     </EventCollector>
 
     <EventCollector Id="Traces_nonpaged_verbose" Name="Event Collector NonPaged (Verbose)">
       <BufferSize Value="1024"/>
-      <Buffers Value="16"/>
+	    <Buffers Value="8" PercentageOfTotalMemory="true" MaximumBufferSpace="64" />
     </EventCollector>
 
     <EventCollector Id="Bthport_ETW" Name="Event Collector Bthport ETW">
       <BufferSize Value="1024"/>
-      <Buffers Value="8" PercentageOfTotalMemory="true" MaximumBufferSpace="64"/>
+	    <Buffers Value="8" PercentageOfTotalMemory="true" MaximumBufferSpace="64" />
     </EventCollector>
 
     <!-- Paged providers. They are kept separate for readability -->


### PR DESCRIPTION
When uploading a wprp file to Feedback Hub the PercentageOfTotalMemory and MaximumBufferSpace tags are required. Adding those tags here allows the two versions of the file to be identical.

How tested:
With wpr.exe
Ran connection, A2dp and HFP scenarios. Validated the the resultant logs files have all of the data that we need.