### PR TITLE
fix proximity sensor crashing on view

### DIFF
--- a/sensors/Tools/SensorExplorer/code/SensorExplorer/Scenario1_View.xaml.cs
+++ b/sensors/Tools/SensorExplorer/code/SensorExplorer/Scenario1_View.xaml.cs
@@ -328,7 +328,7 @@ namespace SensorExplorer
                     SensorDisplay simpleOrientationSensorDisplay = new SensorDisplay(Sensor.SIMPLEORIENTATIONSENSOR, index, totalIndex, "SimpleOrientationSensor", 0, 5, 5, new Color[] { Colors.Lime });
                     sensorDisplay.Add(simpleOrientationSensorDisplay);
                     sensorData.Add(simpleOrientationSensorData);
-                    AddPivotItem(Sensor.PROXIMITYSENSOR, index, totalIndex);
+                    AddPivotItem(Sensor.SIMPLEORIENTATIONSENSOR, index, totalIndex);
                 }
 
                 AddSummaryPage();

--- a/sensors/Tools/SensorExplorer/code/SensorExplorer/Sensor.cs
+++ b/sensors/Tools/SensorExplorer/code/SensorExplorer/Sensor.cs
@@ -22,7 +22,6 @@ namespace SensorExplorer
         public const int GYROMETER = 4;
         public const int INCLINOMETER = 5;
         public const int LIGHTSENSOR = 6;
-        public const int COLORSENSOR = 22;
         public const int ORIENTATIONSENSOR = 7;
         public const int ORIENTATIONRELATIVE = 8;
         public const int ORIENTATIONGEOMAGNETIC = 9;
@@ -1188,7 +1187,7 @@ namespace SensorExplorer
 
                 var deviceProperties = await GetProperties(CustomSensorDeviceInfo[index]);
                 SensorData[totalIndex].AddProperty(deviceId, deviceName, reportInterval, minimumReportInterval, 0, deviceProperties);
-                SensorData[totalIndex].AddPLDProperty(CompassPLD[index]);
+                SensorData[totalIndex].AddPLDProperty(CustomSensorPLD[index]);
                 CustomSensorList[index].ReadingChanged += CustomSensorReadingChanged;
             }
         }
@@ -1529,7 +1528,7 @@ namespace SensorExplorer
                 var deviceProperties = await GetProperties(OrientationRelativeDeviceInfo[index]);
                 SensorData[totalIndex].AddProperty(deviceId, deviceName, reportInterval, minimumReportInterval, 0, deviceProperties);
                 SensorData[totalIndex].AddPLDProperty(OrientationRelativePLD[index]);
-                OrientationRelativeList[totalIndex].ReadingChanged += RelativeOrientationSensorReadingChanged;
+                OrientationRelativeList[index].ReadingChanged += RelativeOrientationSensorReadingChanged;
             }
         }
 
@@ -1603,7 +1602,7 @@ namespace SensorExplorer
                 var deviceProperties = await GetProperties(OrientationGeomagneticDeviceInfo[index]);
                 SensorData[totalIndex].AddProperty(deviceId, deviceName, reportInterval, minimumReportInterval, 0, deviceProperties);
                 SensorData[totalIndex].AddPLDProperty(OrientationGeomagneticPLD[index]);
-                OrientationGeomagneticList[totalIndex].ReadingChanged += OrientationGeomagneticReadingChanged;
+                OrientationGeomagneticList[index].ReadingChanged += OrientationGeomagneticReadingChanged;
             }
         }
 
@@ -1983,7 +1982,7 @@ namespace SensorExplorer
                 var deviceProperties = await GetProperties(ProximitySensorDeviceInfo[index]);
                 SensorData[totalIndex].AddProperty(deviceId, deviceName, 0, 0, 0, deviceProperties);
                 SensorData[totalIndex].AddPLDProperty(ProximitySensorPLD[index]);
-                ProximitySensorList[totalIndex].ReadingChanged += ProximitySensorReadingChanged;
+                ProximitySensorList[index].ReadingChanged += ProximitySensorReadingChanged;
             }
         }
 


### PR DESCRIPTION
In a refactor 3 months ago, there were some copy paste errors with using totalIndex instead of index for three sensors(relative orientation, geomagnetic orientation, and proximity sensor). This caused a crash in sensor explorer whenever you navigated to that view due to an out of bounds error.

Fixed 3 other minor things as well:
1. removed COLORSENSOR due to being exposed as a light sensor and another sensor also having 22 as a value.
2. Fixed a typo where CustomSensorPLD was mistakenly written as CompassPLD
3. Fixed a typo where SIMPLEORIENTATIONSENSOR was mistakenly written as PROXIMITYSENSOR