### PR TITLE
readd distance page without extra config stuff

### DIFF
--- a/sensors/Tools/SensorExplorer/App.xaml.cs
+++ b/sensors/Tools/SensorExplorer/App.xaml.cs
@@ -4,6 +4,7 @@
 using System;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
+using Windows.Media.Capture;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
@@ -15,6 +16,8 @@ namespace SensorExplorer
     /// </summary>
     sealed partial class App : Application
     {
+        public MediaCapture MediaCapture;
+
         /// <summary>
         /// Initializes the singleton application object.  This is the first line of authored code
         /// executed, and as such is the logical equivalent of main() or WinMain().

--- a/sensors/Tools/SensorExplorer/NOTICE.txt
+++ b/sensors/Tools/SensorExplorer/NOTICE.txt
@@ -1,0 +1,45 @@
+Busiotools
+
+THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
+Do Not Translate or Localize
+
+This software incorporates components from the projects listed below. The original copyright notices
+and the licenses under which Microsoft received such components are set forth below and are provided for 
+informational purposes only. Microsoft reserves all rights not expressly granted herein, whether by 
+implication, estoppel or otherwise.
+
+1.	OpenCvSharp version 4.4.0.20200725 (https://github.com/shimat/opencvsharp)
+
+%% OpenCvSharp NOTICES AND INFORMATION BEGIN HERE
+=========================================
+BSD 3-Clause License
+
+Copyright (c) 2019, shimat
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+=========================================
+END OF OpenCvSharp NOTICES AND INFORMATION

--- a/sensors/Tools/SensorExplorer/Package.appxmanifest
+++ b/sensors/Tools/SensorExplorer/Package.appxmanifest
@@ -31,5 +31,6 @@
         <Function Type="name:serialPort" />
       </Device>
     </DeviceCapability>
+    <DeviceCapability Name="webcam"/>
   </Capabilities>
 </Package>

--- a/sensors/Tools/SensorExplorer/SampleConfiguration.cs
+++ b/sensors/Tools/SensorExplorer/SampleConfiguration.cs
@@ -15,6 +15,7 @@ namespace SensorExplorer
             new Scenario() { Title = "View", ClassType = typeof(Scenario1View) },
             new Scenario() { Title = "MALT", ClassType = typeof(Scenario2MALT) },
             new Scenario() { Title = "Display Enhancement Override", ClassType = typeof(Scenario3DEO) },
+            new Scenario() { Title = "Distance", ClassType = typeof(Scenario4Distance) },
         };
     }
 

--- a/sensors/Tools/SensorExplorer/Scenario4_Distance.xaml
+++ b/sensors/Tools/SensorExplorer/Scenario4_Distance.xaml
@@ -1,0 +1,30 @@
+﻿<!--Copyright (c) Microsoft Corporation. All rights reserved.-->
+<!--Licensed under the MIT License.-->
+
+<Page
+    x:Class="SensorExplorer.Scenario4Distance"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
+    Background="White">
+
+    <Grid MaxWidth="800">
+        <StackPanel VerticalAlignment="Center">
+            <TextBlock Text="Distance using Camera and a chessboard" TextWrapping="Wrap" FontSize="30"/>
+            <TextBlock Name="ChessboardExplanation" TextWrapping="Wrap" Text="Please print &quot;https://www.mrpt.org/downloads/camera-calibration-checker-board_9x7.pdf&quot; and attach it to a flat board"/>
+            <TextBlock Name="IsDetectChessboard"/>
+            <TextBlock Name="NumSamplesChessboard"/>
+            <TextBlock Name="DistanceFromChessboard"/>
+            <TextBlock Name="Padding1"/>
+            <TextBlock Name="Padding2"/>
+
+            <TextBlock Text="Distance with a proximity sensor" TextWrapping="Wrap" FontSize="30"/>
+            <TextBlock Name="IsDetectedObject"/>
+            <TextBlock Name="NumSamplesProximity"/>
+            <TextBlock Name="DistanceWithProximitySensor"/>
+        </StackPanel>
+    </Grid>
+</Page>

--- a/sensors/Tools/SensorExplorer/Scenario4_Distance.xaml.cs
+++ b/sensors/Tools/SensorExplorer/Scenario4_Distance.xaml.cs
@@ -1,0 +1,290 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Windows.UI.Core;
+using Windows.Graphics.Display;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Navigation;
+
+using OpenCvSharp;
+using Windows.Graphics.Imaging;
+using System.Runtime.InteropServices;
+using Windows.UI.Xaml.Media.Imaging;
+using Windows.Media.Capture;
+using Windows.Media.Capture.Frames;
+using System.Linq;
+using Windows.Media.MediaProperties;
+using System.Threading;
+using Windows.Devices.Sensors;
+using Windows.Devices.Enumeration;
+using Windows.Foundation;
+
+namespace SensorExplorer
+{
+    public sealed partial class Scenario4Distance : Page
+    {
+        [ComImport]
+        [Guid("5b0d3235-4dba-4d44-865e-8f1d0e4fd04d")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        unsafe interface IMemoryBufferByteAccess
+        {
+            void GetBuffer(out byte* value, out uint capacity);
+        }
+
+        public static Scenario4Distance Scenario4;
+
+        private int m_numberOfGoodChessboardSamples = 0;
+        private double[,] m_cameraMatrix;
+        private double[] m_distCoeffs;
+        private bool m_isLastChessboardSampleGood = false;
+        private List<List<Point3f>> m_objectPoints = new List<List<Point3f>>();
+        private List<List<Point2f>> m_imagePoints = new List<List<Point2f>>();
+        private int m_distanceMm = 0;
+        private MediaCapture m_mediaCapture = null;
+        private MediaFrameReader m_reader = null;
+
+        private const int m_imageNumRows = 720;
+        private const int m_imageNumCols = 1280;
+
+        private ProximitySensor m_sensor;
+        private DeviceWatcher m_watcher;
+        private int m_numberOfGoodProximitySamples = 0;
+
+        MainPage rootPage = MainPage.Current;
+
+        public Scenario4Distance()
+        {
+            InitializeComponent();
+            Scenario4 = this;
+
+            InitMediaCapture();
+
+            m_watcher = DeviceInformation.CreateWatcher(ProximitySensor.GetDeviceSelector());
+            m_watcher.Added += OnProximitySensorAdded;
+            m_watcher.Start();
+        }
+
+        public async void InitMediaCapture()
+        {
+            var allGroups = await MediaFrameSourceGroup.FindAllAsync();
+            var sourceGroups = allGroups.Select(g => new
+            {
+                Group = g,
+                SourceInfo = g.SourceInfos.FirstOrDefault(i => i.SourceKind == MediaFrameSourceKind.Color)
+            }).Where(g => g.SourceInfo != null).ToList();
+
+            if (sourceGroups.Count == 0)
+            {
+                return;
+            }
+            var selectedSource = sourceGroups.FirstOrDefault();
+
+            m_mediaCapture = null;
+            m_mediaCapture = new MediaCapture();
+
+            var settings = new MediaCaptureInitializationSettings()
+            {
+                SourceGroup = selectedSource.Group,
+                SharingMode = MediaCaptureSharingMode.ExclusiveControl,
+                StreamingCaptureMode = StreamingCaptureMode.Video,
+                MemoryPreference = MediaCaptureMemoryPreference.Cpu
+            };
+
+            // Set the MediaCapture to a variable in App.xaml.cs to handle suspension.
+            (App.Current as App).MediaCapture = m_mediaCapture;
+
+            await m_mediaCapture.InitializeAsync(settings);
+
+            MediaFrameSource frameSource = m_mediaCapture.FrameSources[selectedSource.SourceInfo.Id];
+            BitmapSize size = new BitmapSize()
+            {
+                Height = m_imageNumRows,
+                Width = m_imageNumCols
+            };
+            m_reader = await m_mediaCapture.CreateFrameReaderAsync(frameSource, MediaEncodingSubtypes.Bgra8, size);
+            m_reader.FrameArrived += ColorFrameReader_FrameArrivedAsync;
+            await m_reader.StartAsync();
+        }
+
+        private async void ColorFrameReader_FrameArrivedAsync(MediaFrameReader sender, MediaFrameArrivedEventArgs args)
+        {
+            var frame = sender.TryAcquireLatestFrame();
+
+            if (frame != null)
+            {
+                var inputBitmap = frame.VideoMediaFrame?.SoftwareBitmap;
+
+                if (inputBitmap != null)
+                {
+                    SoftwareBitmap originalBitmap = SoftwareBitmap.Convert(inputBitmap, BitmapPixelFormat.Bgra8, BitmapAlphaMode.Premultiplied);
+
+                    await CheckerboardDetectorAsync(originalBitmap);
+                }
+            }
+        }
+
+        public async System.Threading.Tasks.Task CheckerboardDetectorAsync(SoftwareBitmap input)
+        {
+            Mat mInput = SoftwareBitmapToMat(input);
+            Mat gray = mInput.CvtColor(ColorConversionCodes.BGRA2GRAY);
+            List<Point2f> corners = new List<Point2f>();
+            bool foundCorners = Cv2.FindChessboardCorners(gray, new OpenCvSharp.Size(9, 7), OutputArray.Create(corners));
+            TermCriteria criteria = TermCriteria.Both(30, 0.0001);
+
+            if (foundCorners)
+            {
+                Cv2.CornerSubPix(gray, corners, new OpenCvSharp.Size(11, 11), new OpenCvSharp.Size(-1, -1), criteria);
+
+                bool foundBoard = false;
+                Cv2.DrawChessboardCorners(mInput, new OpenCvSharp.Size(9, 7), corners, foundBoard);
+
+                m_numberOfGoodChessboardSamples++;
+
+                List<Point3f> objLocation = new List<Point3f>();
+                for (int i = 0; i < 7; ++i)
+                {
+                    for (int j = 0; j < 9; ++j)
+                    {
+                        objLocation.Add(new Point3f(j * 20, i * 20, 0));
+                    }
+                }
+
+                if (m_numberOfGoodChessboardSamples <= 20)
+                {
+                    m_objectPoints.Add(objLocation);
+                    m_imagePoints.Add(corners);
+                }
+
+                if (m_numberOfGoodChessboardSamples == 20)
+                {
+                    double[,] cameraMatrix = new double[,] { { 1, 0, 0 }, { 0, 1, 0 }, { 0, 0, 1 } };
+                    double[] distCoeffs = new double[] { 0, 0, 0, 0, 0, 0, 0, 0 };
+                    Vec3d[] rvecs = { };
+                    Vec3d[] tvecs = { };
+
+                    Cv2.CalibrateCamera(m_objectPoints, m_imagePoints, new OpenCvSharp.Size(1280, 720), cameraMatrix, distCoeffs, out rvecs, out tvecs);
+
+                    m_cameraMatrix = cameraMatrix;
+                    m_distCoeffs = distCoeffs;
+                }
+
+                if (m_numberOfGoodChessboardSamples >= 20)
+                {
+                    double[] rvecs2 = { };
+                    double[] tvecs2 = { };
+
+                    Cv2.SolvePnP(objLocation, corners, m_cameraMatrix, m_distCoeffs, ref rvecs2, ref tvecs2);
+                    m_distanceMm = (int)Math.Round(Math.Sqrt(tvecs2[0] * tvecs2[0] + tvecs2[1] * tvecs2[1] + tvecs2[2] * tvecs2[2]));
+                }
+            }
+
+            m_isLastChessboardSampleGood = foundCorners;
+
+            await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
+            {
+                this.IsDetectChessboard.Text = "Object is " + (m_isLastChessboardSampleGood ? "detected" : "not detected") + " with the camera";
+                this.NumSamplesChessboard.Text = "Number of detected chessboards: " + m_numberOfGoodChessboardSamples;
+                if (m_numberOfGoodChessboardSamples < 20)
+                {
+                    this.DistanceFromChessboard.Text = "Calibrating ... Wait for 20 complete samples";
+                }
+                else
+                {
+                    this.DistanceFromChessboard.Text = "Distance from camera: " + m_distanceMm + " mm";
+                }
+            });
+        }
+
+        public static unsafe Mat SoftwareBitmapToMat(SoftwareBitmap softwareBitmap)
+        {
+            BitmapBuffer buffer = softwareBitmap.LockBuffer(BitmapBufferAccessMode.Write);
+            var reference = buffer.CreateReference();
+            ((IMemoryBufferByteAccess)reference).GetBuffer(out var dataInBytes, out var capacity);
+
+            Mat outputMat = new Mat(softwareBitmap.PixelHeight, softwareBitmap.PixelWidth, MatType.CV_8UC4, (IntPtr)dataInBytes);
+            return outputMat;
+        }
+
+        public static unsafe void MatToSoftwareBitmap(Mat input, SoftwareBitmap output)
+        {
+            BitmapBuffer buffer = output.LockBuffer(BitmapBufferAccessMode.ReadWrite);
+            var reference = buffer.CreateReference();
+            ((IMemoryBufferByteAccess)reference).GetBuffer(out var dataInBytes, out var capacity);
+            BitmapPlaneDescription layout = buffer.GetPlaneDescription(0);
+
+            for (int i = 0; i < layout.Height; i++)
+            {
+                for (int j = 0; j < layout.Width; j++)
+                {
+                    for (int k = 0; k < 4; k++)
+                    {
+                        dataInBytes[layout.StartIndex + layout.Stride * i + 4 * j + k] =
+                        input.DataPointer[layout.StartIndex + layout.Stride * i + 4 * j + k];
+                    }
+                }
+            }
+        }
+
+        private async void OnProximitySensorAdded(DeviceWatcher sender, DeviceInformation device)
+        {
+            if (null == m_sensor)
+            {
+                ProximitySensor foundSensor = ProximitySensor.FromId(device.Id);
+                if (null != foundSensor)
+                {
+                    if (null == foundSensor.MaxDistanceInMillimeters)
+                    {
+                        await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+                        {
+                            rootPage.NotifyUser("Proximity sensor does not report detection ranges, using it anyway", NotifyType.StatusMessage);
+                        });
+                    }
+
+                    m_sensor = foundSensor;
+                    m_sensor.ReadingChanged += new TypedEventHandler<ProximitySensor, ProximitySensorReadingChangedEventArgs>(ReadingChanged);
+                }
+                else
+                {
+                    await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+                    {
+                        rootPage.NotifyUser("Could not get a proximity sensor from the device id", NotifyType.ErrorMessage);
+                    });
+                }
+            }
+        }
+
+        protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
+        {
+            if (null != m_sensor)
+            {
+                m_sensor.ReadingChanged -= new TypedEventHandler<ProximitySensor, ProximitySensorReadingChangedEventArgs>(ReadingChanged);
+            }
+            base.OnNavigatingFrom(e);
+        }
+
+        async private void ReadingChanged(ProximitySensor sender, ProximitySensorReadingChangedEventArgs e)
+        {
+            await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            {
+                ProximitySensorReading reading = e.Reading;
+                if (null != reading)
+                {
+                    m_numberOfGoodProximitySamples++;
+
+                    IsDetectedObject.Text = "Object is " + (reading.IsDetected ? "detected" : "not detected") + " with the proximity sensor";
+                    NumSamplesProximity.Text = "Number of good detections with proximity sensor: " + m_numberOfGoodProximitySamples;
+
+                    // Show the detection distance, if available
+                    if (null != reading.DistanceInMillimeters)
+                    {
+                        DistanceWithProximitySensor.Text = "Distance with the proximity sensor: " + reading.DistanceInMillimeters.ToString() + " mm";
+                    }
+                }
+            });
+        }
+    }
+}

--- a/sensors/Tools/SensorExplorer/SensorExplorer.csproj
+++ b/sensors/Tools/SensorExplorer/SensorExplorer.csproj
@@ -38,6 +38,7 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>
@@ -50,6 +51,7 @@
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <DebugSymbols>true</DebugSymbols>
@@ -61,6 +63,7 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
     <OutputPath>bin\ARM\Release\</OutputPath>
@@ -73,6 +76,7 @@
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -84,6 +88,7 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
@@ -96,6 +101,7 @@
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
@@ -127,6 +133,7 @@
     <Compile Include="Scenario3_DEO.xaml.cs">
       <DependentUpon>Scenario3_DEO.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Scenario4_Distance.xaml.cs" />
     <Compile Include="Sensor.cs" />
     <Compile Include="SensorData.cs" />
     <Compile Include="SensorDisplay.cs" />
@@ -222,6 +229,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Scenario4_Distance.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <None Include="SensorExplorer_TemporaryKey.pfx" />
@@ -233,6 +244,12 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls">
       <Version>5.1.1</Version>
+    </PackageReference>
+    <PackageReference Include="OpenCvSharp4">
+      <Version>4.4.0.20200725</Version>
+    </PackageReference>
+    <PackageReference Include="OpenCvSharp4.runtime.uwp">
+      <Version>4.4.0.20200725</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">


### PR DESCRIPTION
Added a extra page for getting distance

This page does has 2 seperate ways of getting distance.
1. Via the camera detecting a chessboard that you can print here: "https://www.mrpt.org/downloads/camera-calibration-checker-board_9x7.pdf"
2. Via a proximity sensor on the device

This page allows users to compare their value from the camera and the proximity sensor to measure if the value from the proximity sensor is in the correct ballpark

Verified via:
Tested SensorExplorer on device without camera access but with proximity sensor
Tested SensorExplorer on device without proximity sensor but with camera
Tested SensorExplorer on device with both camera and proximity sensor