### PR TITLE
Boot trace fix for camera, 

### DIFF
--- a/camera/Tracing/Trace.ps1
+++ b/camera/Tracing/Trace.ps1
@@ -158,7 +158,7 @@ function Main {
                 Write-Host "Gathering system information..."
                 Get-EnvironmentInformation
 
-                $script:StopScripts = @(Get-ChildItem -Path $path -Filter *_stop.cmd | select -ExpandProperty FullName)
+                $script:StopScripts = @(Get-ChildItem -Path $StopBootTrace -Filter *_stop.cmd -Recurse | select -ExpandProperty FullName)
 
                 # Put scripts on device, if needed.
                 Write-Host "Preparing target system..."


### PR DESCRIPTION
- wrong path was used to stop the trace after boot trace was started. Resulting that the stop cmd was never executed.