### PR TITLE
Adding i8042prt and HidSpiCx to HidOnlyProfile

### DIFF
--- a/usb/tracing/BusesAllProfile.wprp
+++ b/usb/tracing/BusesAllProfile.wprp
@@ -246,6 +246,11 @@
         <Keyword Value="0xFFFFFFFFFFFFFFFF" />
       </Keywords>
     </EventProvider>
+    <EventProvider Id="HidSpiCx" Name="5ed8bb73-c76f-49d9-bf05-4982903c6ca5" NonPagedMemory="true" Level="5">
+      <Keywords>
+        <Keyword Value="0xFFFFFFFFFFFFFFFF" />
+      </Keywords>
+    </EventProvider>
     <EventProvider Id="Hidinterrupt" Name="78396E52-9753-4D63-8CF5-A936B4989FF2" NonPagedMemory="true" Level="5">
       <Keywords>
         <Keyword Value="0xFFFFFFFFFFFFFFFF" />
@@ -452,6 +457,7 @@
         <EventCollectorId Value="EventCollector_DiagTrack_5cfb325a347145dda3b17990b1675ac9_3">
           <EventProviders>
             <EventProviderId Value="Hidspi" />
+            <EventProviderId Value="HidSpiCx" />
             <EventProviderId Value="Hidinterrupt" />
             <EventProviderId Value="HidTelephonyTraceGuid" />
             <EventProviderId Value="BTNCONV" />
@@ -496,6 +502,7 @@
         <EventCollectorId Value="EventCollector_DiagTrack_5cfb325a347145dda3b17990b1675ac9_3">
           <EventProviders>
             <EventProviderId Value="Hidspi" />
+            <EventProviderId Value="HidSpiCx" />
             <EventProviderId Value="Hidinterrupt" />
             <EventProviderId Value="HidTelephonyTraceGuid" />
             <EventProviderId Value="Msgpiowin32" />

--- a/usb/tracing/BusesAllProfile.wprp
+++ b/usb/tracing/BusesAllProfile.wprp
@@ -400,7 +400,6 @@
       <Collectors>
         <EventCollectorId Value="EventCollector_DiagTrack_5cfb325a347145dda3b17990b1675ac9_0">
           <EventProviders>
-            <EventProviderId Value="CadEtw" />
             <EventProviderId Value="Msgpiowin32" />
             <EventProviderId Value="I8042prt" />
             <EventProviderId Value="Buttonconverter" />
@@ -447,6 +446,7 @@
             <EventProviderId Value="UcmUcsiCxAcpiClient" />
             <EventProviderId Value="UsbPmApiWpp" />
             <EventProviderId Value="UsbCApiWpp" />
+            <EventProviderId Value="CadEtw" />
           </EventProviders>
         </EventCollectorId>
         <EventCollectorId Value="EventCollector_DiagTrack_5cfb325a347145dda3b17990b1675ac9_3">
@@ -454,7 +454,6 @@
             <EventProviderId Value="Hidspi" />
             <EventProviderId Value="Hidinterrupt" />
             <EventProviderId Value="HidTelephonyTraceGuid" />
-            <EventProviderId Value="Msgpiowin32" />
             <EventProviderId Value="BTNCONV" />
             <EventProviderId Value="HIDVHF" />
             <EventProviderId Value="HidClassWpp" />
@@ -511,6 +510,7 @@
             <EventProviderId Value="KbdClass" />
             <EventProviderId Value="MouHid" />
             <EventProviderId Value="MouClass" />
+            <EventProviderId Value="I8042prt" />
             <EventProviderId Value="MtConfig" />
             <EventProviderId Value="RIM_RS1" />
             <EventProviderId Value="Win32kBaseInput" />
@@ -648,6 +648,7 @@
             <EventProviderId Value="UcmUcsiCxAcpiClient" />
             <EventProviderId Value="UsbPmApiWpp" />
             <EventProviderId Value="UsbCApiWpp" />
+            <EventProviderId Value="CadEtw" />
           </EventProviders>
         </EventCollectorId>
       </Collectors>


### PR DESCRIPTION
i8042prt is currently only included in the "BusesAllProfile" profile. When choosing "HidOnlyProfile", it's not included.

The PR adds i8042prt to the "HidOnlyProfile" profile as well. Technically, PS/2 isn't HID. But "HidTrace" is the most appropriate among all the existing event collectors here.

The PR also adds HidSpiCx to the "HidOnlyProfile" profile as well as the "BusesAllProfile" profile.

In addition, the PR includes the following two more updates for the "BusesAllProfile" profile for correction.

- moving "CADETW" from "ButtonsTrace" to "UsbCAndUsbFnTrace", since it belongs to USB-C instead of buttons.
- removing "msgpiowin32" from "HidTrace", since it's already in "ButtonsTrace". 

Verification
========
Tested locally using wpr.exe by specifying !BusesAllProfile, !HidOnlyProfile, !UsbCOnlyProfile and no profile.
