### PR TITLE
Capture stacks for some events in BluetoothStack.wprp

### DIFF
--- a/bluetooth/tracing/BluetoothStack.wprp
+++ b/bluetooth/tracing/BluetoothStack.wprp
@@ -8,6 +8,11 @@
   Tag="">
   <Profiles>
 
+    <SystemCollector Id="SystemCollector">
+      <BufferSize Value="1024"/>
+      <Buffers Value="20"/>
+    </SystemCollector>
+
     <EventCollector Id="Traces_paged" Name="Event Collector Paged">
       <BufferSize Value="1024"/>
       <Buffers Value="8" PercentageOfTotalMemory="true" MaximumBufferSpace="64"/>
@@ -32,6 +37,13 @@
       <BufferSize Value="1024"/>
       <Buffers Value="8" PercentageOfTotalMemory="true" MaximumBufferSpace="64"/>
     </EventCollector>
+
+    <SystemProvider Id="SystemProvider">
+      <Keywords>
+        <Keyword Value="Loader"/>
+        <Keyword Value="ProcessThread"/>
+      </Keywords>
+    </SystemProvider>
 
     <!-- Paged providers. They are kept separate for readability -->
     <EventProvider Id="Microsoft.Windows.Bluetooth.BTCMClientProvider" Name="B67069E7-206C-4e4c-80CE-4663560EA07F" Level="4" NonPagedMemory="false">
@@ -721,6 +733,15 @@
       </Keywords>
     </EventProvider>
 
+    <EventProvider Id="Microsoft.Windows.Bluetooth.BTHPORT.WithStacks" Name="8a1f9517-3a8c-4a9e-a018-4f17a200f277" Level="4" NonPagedMemory="true">
+      <Keywords>
+        <Keyword Value="0x0"/>
+      </Keywords>
+      <StackFilters FilterIn="true">
+        <EventId Value="403" />
+      </StackFilters>
+    </EventProvider>
+
     <!-- Handsfree ETW providers. Kept separate for readability -->
     <EventProvider Id="Microsoft.Windows.Apps.CommsEnhancementRTProviders" Name="7665d4fd-30eb-4ddc-9dc1-4ebab74ed98e" Level="5" NonPagedMemory="false">
       <Keywords>
@@ -1149,6 +1170,22 @@
           </EventProviders>
         </EventCollectorId>
 
+      </Collectors>
+    </Profile>
+
+    <Profile Id="BluetoothStackWithSystemProvider.Verbose.File" LoggingMode="File" Base="BluetoothStack.Verbose.File" Name="BluetoothStackWithSystemProvider" DetailLevel="Verbose" Description="Bluetooth stack profile that includes the System provider">
+      <Collectors Operation="Remove">
+        <EventCollectorId Value="Bthport_ETW" />
+      </Collectors>
+      <Collectors Operation="Add">
+        <SystemCollectorId Value="SystemCollector">
+          <SystemProviderId Value="SystemProvider" />
+        </SystemCollectorId>
+        <EventCollectorId Value="Bthport_ETW">
+          <EventProviders>
+            <EventProviderId Value="Microsoft.Windows.Bluetooth.BTHPORT.WithStacks"/>
+          </EventProviders>
+        </EventCollectorId>
       </Collectors>
     </Profile>
 

--- a/bluetooth/tracing/readme.md
+++ b/bluetooth/tracing/readme.md
@@ -13,7 +13,7 @@ More details can be found in the [Additional Information](#Additional-Informatio
 1. From an administrative PowerShell session run:
 
     ```powershell
-    wget https://github.com/Microsoft/busiotools/raw/master/bluetooth/tracing/BluetoothStack.wprp -outfile .\BluetoothStack.wprp
+    Invoke-WebRequest https://github.com/Microsoft/busiotools/raw/master/bluetooth/tracing/BluetoothStack.wprp -outfile .\BluetoothStack.wprp
     wpr.exe -start BluetoothStack.wprp!BluetoothStack -filemode
     ```
     The above commands download and run the Bluetooth tracing Recording Profile ([BluetoothStack.wprp](./BluetoothStack.wprp))
@@ -31,7 +31,7 @@ More details can be found in the [Additional Information](#Additional-Informatio
 ## Autologger mode (collects logs across reboots)
 1. From an adminstrative PowerShell session:
      ```powershell
-    wget https://github.com/Microsoft/busiotools/raw/master/bluetooth/tracing/BluetoothStack.wprp -UseBasicParsing -outfile .\BluetoothStack.wprp
+    Invoke-WebRequest https://github.com/Microsoft/busiotools/raw/master/bluetooth/tracing/BluetoothStack.wprp -UseBasicParsing -outfile .\BluetoothStack.wprp
     wpr.exe -boottrace -addboot BluetoothStack.wprp!BluetoothStack -filemode
     shutdown -r -f -t 0
     ```
@@ -57,7 +57,7 @@ Some additional information on the log collection steps above.
 ### How to Collect Bluetooth Radio Information
 From PowerShell execute:
 ```powershell
-wget https://github.com/Microsoft/busiotools/raw/master/bluetooth/tracing/GetBluetoothRadioInfo.ps1 -UseBasicParsing | iex
+Invoke-WebRequest https://github.com/Microsoft/busiotools/raw/master/bluetooth/tracing/GetBluetoothRadioInfo.ps1 -UseBasicParsing | iex
 ```
 
 ### Verbose/Non-verbose logs
@@ -70,7 +70,7 @@ The above collects Verbose logs by default. If you don't need verbose logs, repl
 ### Collecting logs for performance issues
 1. From an administrative PowerShell session:
     ```powershell
-    wget https://github.com/Microsoft/busiotools/raw/master/bluetooth/tracing/BluetoothStack.wprp -outfile .\BluetoothStack.wprp
+    Invoke-WebRequest https://github.com/Microsoft/busiotools/raw/master/bluetooth/tracing/BluetoothStack.wprp -outfile .\BluetoothStack.wprp
     wpr.exe -start BluetoothStack.wprp!BluetoothStack.Light -start CPU -filemode
     ```
     The above commands download and run the Bluetooth tracing Recording Profile ([BluetoothStack.wprp](./BluetoothStack.wprp)) to collect performance logs.

--- a/bluetooth/tracing/readme.md
+++ b/bluetooth/tracing/readme.md
@@ -1,41 +1,41 @@
 # How to collect Bluetooth logs
- 
+
 **This information is targeted to developers, for non-developer information on troubleshooting Bluetooth, see [Fix Bluetooth problems in Windows 10](https://support.microsoft.com/en-us/help/14169/windows-10-fix-bluetooth-problems).**
 
-This readme covers how developers can collect Bluetooth logs for bugs using [Windows Performance Recorder (WPR)](https://docs.microsoft.com/en-us/windows-hardware/test/wpt/introduction-to-wpr) using the custom Bluetooth tracing [Recording Profile](https://docs.microsoft.com/en-us/windows-hardware/test/wpt/wpr-quick-start#using-recording-profiles) found here: [BluetoothStack.wprp](./BluetoothStack.wprp). There are few ways you can collect these logs: 
+This readme covers how developers can collect Bluetooth logs for bugs using [Windows Performance Recorder (WPR)](https://docs.microsoft.com/en-us/windows-hardware/test/wpt/introduction-to-wpr) using the custom Bluetooth tracing [Recording Profile](https://docs.microsoft.com/en-us/windows-hardware/test/wpt/wpr-quick-start#using-recording-profiles) found here: [BluetoothStack.wprp](./BluetoothStack.wprp). There are few ways you can collect these logs:
 * [Normal Mode (cancels on reboot)](#Normal-Mode-cancels-on-reboot): Tracing for a single boot session, will not continue tracing after a reboot
 * [Autologger mode (collects logs across reboots)](#Autologger-mode-collects-logs-across-reboots): Tracing for running across reboots until you stop it manually
-> Note: Only one of the above methods can be used at a time. 
+> Note: Only one of the above methods can be used at a time.
 
 More details can be found in the [Additional Information](#Additional-Information) section.
- 
+
 ## Normal Mode (cancels on reboot)
 1. From an administrative PowerShell session run:
 
     ```powershell
-        wget https://github.com/Microsoft/busiotools/raw/master/bluetooth/tracing/BluetoothStack.wprp -outfile .\BluetoothStack.wprp
-        wpr.exe -start BluetoothStack.wprp!BluetoothStack -filemode
+    wget https://github.com/Microsoft/busiotools/raw/master/bluetooth/tracing/BluetoothStack.wprp -outfile .\BluetoothStack.wprp
+    wpr.exe -start BluetoothStack.wprp!BluetoothStack -filemode
     ```
     The above commands download and run the Bluetooth tracing Recording Profile ([BluetoothStack.wprp](./BluetoothStack.wprp))
 
 1. To ensure we capture connections either:
     * Toggle the Bluetooth radio off-on via the quick action menu.
     * Force a power cycle of the remote device.
-    
+
 1. *Reproduce the issue.*
 
 1. From an administrative PowerShell session:
     ```powershell
-        wpr.exe -stop BthTracing.etl
+    wpr.exe -stop BthTracing.etl
     ````
 ## Autologger mode (collects logs across reboots)
 1. From an adminstrative PowerShell session:
-     ```powershell   
-        wget https://github.com/Microsoft/busiotools/raw/master/bluetooth/tracing/BluetoothStack.wprp -UseBasicParsing -outfile .\BluetoothStack.wprp
-        wpr.exe -boottrace -addboot BluetoothStack.wprp!BluetoothStack -filemode
-        shutdown -r -f -t 0
+     ```powershell
+    wget https://github.com/Microsoft/busiotools/raw/master/bluetooth/tracing/BluetoothStack.wprp -UseBasicParsing -outfile .\BluetoothStack.wprp
+    wpr.exe -boottrace -addboot BluetoothStack.wprp!BluetoothStack -filemode
+    shutdown -r -f -t 0
     ```
-      The above commands download and run the Bluetooth tracing Recording Profile ([BluetoothStack.wprp](./BluetoothStack.wprp)) in Autologger mode.
+    The above commands download and run the Bluetooth tracing Recording Profile ([BluetoothStack.wprp](./BluetoothStack.wprp)) in Autologger mode.
 1. Reboot the machine:
     * trace is not running until you reboot the machine
     * log will keep running across reboots until you stop it manually
@@ -43,19 +43,19 @@ More details can be found in the [Additional Information](#Additional-Informatio
 
 1. From an adminstrative PowerShell session:
     ```powershell
-     wpr.exe -boottrace -stopboot BthTracing.etl
+    wpr.exe -boottrace -stopboot BthTracing.etl
     ```
     This command stops tracing, if you want to start tracing again you'll need to start it again.
 
-    > Note: To see the status of an autologger trace run the following command:`
-    Wpr -status -instancename wprapp_boottr`
+    > Note: To see the status of an autologger trace run the following command:
+    `wpr.exe -status -instancename wprapp_boottr`
 
 ## Additional Information
 
 Some additional information on the log collection steps above.
 
 ### How to Collect Bluetooth Radio Information
-From PowerShell execute: 
+From PowerShell execute:
 ```powershell
 wget https://github.com/Microsoft/busiotools/raw/master/bluetooth/tracing/GetBluetoothRadioInfo.ps1 -UseBasicParsing | iex
 ```
@@ -70,20 +70,20 @@ The above collects Verbose logs by default. If you don't need verbose logs, repl
 ### Collecting logs for performance issues
 1. From an administrative PowerShell session:
     ```powershell
-        wget https://github.com/Microsoft/busiotools/raw/master/bluetooth/tracing/BluetoothStack.wprp -outfile .\BluetoothStack.wprp
-        wpr.exe -start BluetoothStack.wprp!BluetoothStack.Light -start CPU -filemode
+    wget https://github.com/Microsoft/busiotools/raw/master/bluetooth/tracing/BluetoothStack.wprp -outfile .\BluetoothStack.wprp
+    wpr.exe -start BluetoothStack.wprp!BluetoothStack.Light -start CPU -filemode
     ```
     The above commands download and run the Bluetooth tracing Recording Profile ([BluetoothStack.wprp](./BluetoothStack.wprp)) to collect performance logs.
     >*Note: This will not continue tracing after a reboot*
 1. To ensure the device reconnects either:
     * Toggle the Bluetooth radio off-on via the quick action menu.
     * Force a power cycle of the remote device.
-    
+
 1. *Reproduce the issue.*
 
 1. From an administrative PowerShell session:
     ```powershell
-        wpr.exe -stop BthTracing_CPU.etl
+    wpr.exe -stop BthTracing_CPU.etl
     ````
 
 ### More info on Windows Performance Recorder (WPR)


### PR DESCRIPTION
Updated BluetoothStack.wprp to capture stacks for some events, and include the SystemProvider to enable decoding those stacks.

Also updated the README to fix some formatting, and replace the use of `wget` with `Invoke-WebRequest` directly, since the former is not available in PowerShell7.
