### PR TITLE
Add new profile for USB4 + IHV Graphics Providers

### DIFF
--- a/usb/tracing/BusesAllProfile.wprp
+++ b/usb/tracing/BusesAllProfile.wprp
@@ -41,6 +41,10 @@
       <BufferSize Value="64" />
       <Buffers Value="1.4" PercentageOfTotalMemory="true" MaximumBufferSpace="32" />
     </EventCollector>
+    <EventCollector Id="EventCollector_Display_Extended" Name="ExtendedDisplayTrace">
+      <BufferSize Value="64" />
+      <Buffers Value="3" PercentageOfTotalMemory="true" MaximumBufferSpace="120" />
+    </EventCollector>
     <EventCollector Id="EventCollector_NdisNetCx" Name="NdisNetCxTrace">
       <BufferSize Value="64" />
       <Buffers Value="1.4" PercentageOfTotalMemory="true" MaximumBufferSpace="32" />
@@ -518,6 +522,21 @@
     </EventProvider>
     <EventProvider Id="DisplayWin32K" Name="deb96c0a-d2d9-5868-a5d5-50ee13513c8b" NonPagedMemory="true" Level="5" />
     <EventProvider Id="DisplayDxgDiagnostics" Name="221D444C-D07E-4FDE-B425-15B746CF535B" NonPagedMemory="true" Level="5" />
+    <EventProvider Id="DisplayIHV1" Name="6F556899-027A-45EC-A3F5-C58E7FB94FF5" NonPagedMemory="true" Level="5">
+      <Keywords>
+        <Keyword Value="0xFFFFFFFFFFFFFFFF" />
+      </Keywords>
+    </EventProvider>
+    <EventProvider Id="DisplayIHV2" Name="6381f857-7661-4b04-9521-288319e75f12" NonPagedMemory="true" Level="5">
+      <Keywords>
+        <Keyword Value="0xFFFFFFFFFFFFFFFF" />
+      </Keywords>
+    </EventProvider>
+    <EventProvider Id="DisplayIHV3" Name="31AB337F-8BA3-4145-88F3-CEA537BFE861" NonPagedMemory="true" Level="5">
+      <Keywords>
+        <Keyword Value="0xFFFFFFFFFFFFFFFF" />
+      </Keywords>
+    </EventProvider>
     <EventProvider Id="NetAdapterCxWpp" Name="16D3161E-4883-493F-ACD9-8E2065B82270" NonPagedMemory="true" Level="5">
       <Keywords>
         <Keyword Value="0xFFFFFFFFFFFFFFFF" />
@@ -930,6 +949,63 @@
     <Profile Id="Usb4WithTunnelsProfile.Verbose.File" Name="Usb4WithTunnelsProfile" DetailLevel="Verbose" LoggingMode="File"
       Description="USB3, USB4, PnP, Display, Net and PCI"
       Base="Usb4WithTunnelsProfile.Verbose.Memory"/>
+
+    <Profile Id="Usb4WithExtendedDisplayProfile.Verbose.Memory" Name="Usb4WithExtendedDisplayProfile" DetailLevel="Verbose" LoggingMode="Memory"
+      Description="USB3, USB4, PnP, Display, and PCI">
+      <Collectors>
+        <EventCollectorId Value="EventCollector_Usb">
+          <EventProviders>
+            <EventProviderId Value="UsbXhciCommonEtw" />
+            <EventProviderId Value="UsbXhciCompanionWpp" />
+            <EventProviderId Value="UsbXhciDriverWpp" />
+            <EventProviderId Value="UsbXhciTrustletWpp" />
+            <EventProviderId Value="UcxEtw" />
+            <EventProviderId Value="UcxWpp" />
+            <EventProviderId Value="UsbHub3Etw" />
+            <EventProviderId Value="UsbHub3Wpp" />
+            <EventProviderId Value="QcXhciFilterWpp" />
+            <EventProviderId Value="QcUsbFnSSFilterWpp" />
+            <EventProviderId Value="QcUsbCUcsi8280Wpp" />
+            <EventProviderId Value="NVPEP" />
+          </EventProviders>
+        </EventCollectorId>
+        <EventCollectorId Value="EventCollector_Usb4">
+          <EventProviders>
+            <EventProviderId Value="USB4HrdWpp" />
+            <EventProviderId Value="USB4DrdWpp" />
+            <EventProviderId Value="USB4HrdTlg" />
+            <EventProviderId Value="USB4DrdTlg" />
+            <EventProviderId Value="Usb4NetWpp" />
+            <EventProviderId Value="QcUsb4FilterWpp" />
+            <EventProviderId Value="QcUsb4BusWpp" />
+          </EventProviders>
+        </EventCollectorId>
+        <EventCollectorId Value="EventCollector_PnP">
+          <EventProviders>
+            <EventProviderId Value="Microsoft-Windows-Kernel-PnP" />
+          </EventProviders>
+        </EventCollectorId>
+        <EventCollectorId Value="EventCollector_Pci">
+          <EventProviders>
+            <EventProviderId Value="PciWpp" />
+            <EventProviderId Value="QcPpxWpp" />
+          </EventProviders>
+        </EventCollectorId>
+        <EventCollectorId Value="EventCollector_Display_Extended">
+          <EventProviders>
+            <EventProviderId Value="DisplayDxgDiagnostics" />
+            <EventProviderId Value="DisplayWin32K" />
+            <EventProviderId Value="QcDxkmWpp" />
+            <EventProviderId Value="DisplayIHV1" />
+            <EventProviderId Value="DisplayIHV2" />
+            <EventProviderId Value="DisplayIHV3" />
+          </EventProviders>
+        </EventCollectorId>
+      </Collectors>
+    </Profile>
+    <Profile Id="Usb4WithExtendedDisplayProfile.Verbose.File" Name="Usb4WithExtendedDisplayProfile" DetailLevel="Verbose" LoggingMode="File"
+      Description="USB3, USB4, PnP, Display, and PCI"
+      Base="Usb4WithExtendedDisplayProfile.Verbose.Memory"/>
 
     <Profile Id="USBCProfile.Verbose.Memory" Name="USBCProfile" DetailLevel="Verbose" LoggingMode="Memory"
       Description="USB-C, URS and USBFN">

--- a/usb/tracing/BusesTrace.cmd
+++ b/usb/tracing/BusesTrace.cmd
@@ -115,15 +115,17 @@ echo 2) UsbAndPnPProfile (USB2, USB3, USB4 and PnP)
 echo 3) UsbCProfile (UCM, URS and USBFN)
 echo 4) LowPowerBusesProfile (SerCx2 and SpbCx)
 echo 5) InputOnlyWithVerboseWppProfile (Input)
-echo 6) Back
+echo 6) Usb4WithExtendedDisplayProfile (USB3, USB4, PnP, PCI, Display, and Display IHV providers)
+echo 7) Back
 echo.
 set /p selection=Enter selection number:
 if "%selection%"=="1" set profileName=UsbOnlyProfile
 if "%selection%"=="2" set profileName=UsbAndPnpProfile
 if "%selection%"=="3" set profileName=UsbCProfile
-if "%selection%"=="4" set profileName=LowPowerBUsesProfile
+if "%selection%"=="4" set profileName=LowPowerBusesProfile
 if "%selection%"=="5" set profileName=InputOnlyWithVerboseWppProfile
-if "%selection%"=="6" goto BasicProfilesMenu
+if "%selection%"=="6" set profileName=Usb4WithExtendedDisplayProfile
+if "%selection%"=="7" goto BasicProfilesMenu
 if not "%profileName%"=="" goto StartOptionsMenu
 echo.
 echo "%selection%" is not a valid option.  Please try again.
@@ -276,6 +278,7 @@ rem Collecting DispDiag and if availiable the DES mini dump
 if  "%profileName%"=="SensorsOnlyProfile" goto CollectDispDiag
 if  "%profileName%"=="Usb4WithTunnelsProfile" goto CollectDispDiag
 if  "%profileName%"=="BusesAllProfile" goto CollectDispDiag
+if  "%profileName%"=="Usb4WithExtendedDisplayProfile" goto CollectDispDiag
 goto SkipCollectDispDiag
 :CollectDispDiag
     echo.
@@ -358,4 +361,3 @@ goto End
 endlocal
 echo.
 pause
-


### PR DESCRIPTION
These providers can be quite verbose.  Rather than add 100's of MBs to all USB4 captures, create a new profile that captures the basic USB4 providers (USB4+USB3+PCI+GFX) that could be relevant to a display investigation and include the verbose IHV providers as well.