### PR TITLE
Fix busestrace not collecting sensor minidumps on boot trace stop

### DIFF
--- a/usb/tracing/BusesTrace.cmd
+++ b/usb/tracing/BusesTrace.cmd
@@ -18,6 +18,7 @@ set Buses_Backup_LogMinidumpType=0x1120
 set Buses_Backup_LogEnable=0
 set Buses_Backup_LogFlushPeriodSeconds=300
 set collectPnpStates=1
+set busesTraceRegKey=HKLM\Software\Microsoft\BusesTrace
 
 if not exist %wprpFileName% (
     echo.
@@ -201,6 +202,9 @@ echo Configuring Boot Session Trace... (%wprpFileName%!%profileName%)
 wpr.exe -addboot %wprpFileName%!%profileName% -filemode -recordTempTo %traceFilesOutputPath%\
 if not %ERRORLEVEL%==0 goto End
 
+rem Save the profile name to registry so we can retrieve it when stopping the boot trace.
+REG.EXE ADD "%busesTraceRegKey%" /v ProfileName /t REG_SZ /d %profileName% /f
+
 echo.
 echo ###############################################################################
 echo Please reboot your PC to start tracing. After reproducing the issue, run this
@@ -210,6 +214,9 @@ echo.
 goto End
 
 :StopBootTrace
+rem Restore the profile name saved when the boot trace was configured.
+FOR /F "skip=2 tokens=3" %%v IN ('reg.exe query "%busesTraceRegKey%" /v ProfileName 2^>nul') DO set profileName=%%v
+REG.EXE DELETE "%busesTraceRegKey%" /v ProfileName /f >nul 2>&1
 echo Saving WPR status to %busesTraceInfoFileName%...
 wpr.exe -status profiles collectors -details > %traceFilesOutputPath%\%busesTraceInfoFileName%
 echo Stopping boot session tracing...
@@ -275,10 +282,6 @@ if exist %SystemRoot%\LiveKernelReports\USB* (
 
 
 rem Collecting DispDiag and if available the DES mini dump
-rem Note: when stopping a boot trace, profileName is not set (the user only
-rem selects "Stop Boot Session Trace" without choosing a profile), so we
-rem always collect DispDiag and minidumps in that case since we can't
-rem determine which profile was used to start the boot trace.
 if  "%profileName%"=="SensorsOnlyProfile" goto CollectDispDiag
 if  "%profileName%"=="Usb4WithTunnelsProfile" goto CollectDispDiag
 if  "%profileName%"=="BusesAllProfile" goto CollectDispDiag

--- a/usb/tracing/BusesTrace.cmd
+++ b/usb/tracing/BusesTrace.cmd
@@ -274,11 +274,16 @@ if exist %SystemRoot%\LiveKernelReports\USB* (
 )
 
 
-rem Collecting DispDiag and if availiable the DES mini dump
+rem Collecting DispDiag and if available the DES mini dump
+rem Note: when stopping a boot trace, profileName is not set (the user only
+rem selects "Stop Boot Session Trace" without choosing a profile), so we
+rem always collect DispDiag and minidumps in that case since we can't
+rem determine which profile was used to start the boot trace.
 if  "%profileName%"=="SensorsOnlyProfile" goto CollectDispDiag
 if  "%profileName%"=="Usb4WithTunnelsProfile" goto CollectDispDiag
 if  "%profileName%"=="BusesAllProfile" goto CollectDispDiag
 if  "%profileName%"=="Usb4WithExtendedDisplayProfile" goto CollectDispDiag
+if  "%profileName%"=="" goto CollectDispDiag
 goto SkipCollectDispDiag
 :CollectDispDiag
     echo.
@@ -286,10 +291,10 @@ goto SkipCollectDispDiag
     dispdiag.exe
     move "%scriptDirectory%*.dat" %traceFilesOutputPath%
 
-    if exist %miniDumpCollectionScript% (
+    if exist %scriptDirectory%%miniDumpCollectionScript% (
         echo Now collecting sensor process minidumps
         pushd "%~dp0"
-        powershell -ExecutionPolicy bypass -file "%miniDumpCollectionScript%" -FileList "Microsoft.Graphics.Display.DisplayEnhancementService.dll umpoext.dll sensorservice.dll SensorsCx.dll" -OutputPath "%traceFilesOutputPath%"
+        powershell -ExecutionPolicy bypass -file "%scriptDirectory%%miniDumpCollectionScript%" -FileList "Microsoft.Graphics.Display.DisplayEnhancementService.dll umpoext.dll sensorservice.dll SensorsCx.dll" -OutputPath "%traceFilesOutputPath%"
         copy %SYSTEMROOT%\system32\DispDiag*.dat %traceFilesOutputPath% >nul 2>&1
         popd
     )


### PR DESCRIPTION
Fixing an issue that causes busestrace to not collect sensor minidumps on boot trace stop.

Two bugs prevented minidump collection when stopping a boot session trace:

1) profileName is not set when the user selects 'Stop Boot Session Trace' from the main menu (it is only set when starting a new trace via the profile selection menu). The profileName gate at CollectDispDiag therefore always fell through to SkipCollectDispDiag, skipping minidump collection entirely. Fixed by also entering CollectDispDiag when profileName is empty (boot trace stop path).

2) miniDumpCollectionScript used a relative path for the 'if exist' check, so it would fail if the user's current directory differed from the script directory. Fixed by prepending scriptDirectory.